### PR TITLE
Update login and create user

### DIFF
--- a/app/src/main/java/com/rrc/adev3007/pixel_perfect/the_y_app/CreateUserActivity.kt
+++ b/app/src/main/java/com/rrc/adev3007/pixel_perfect/the_y_app/CreateUserActivity.kt
@@ -216,9 +216,16 @@ fun CreateUserScreen(viewModel: SessionViewModel) {
                                     Log.e("loginError", response.code().toString())
                                     if (response.code() == 416) {
                                         val updatedErrors = userViewModel.errors.toMutableMap()
-                                        updatedErrors["username"] = "User already exists"
+                                        updatedErrors["username"] = "Username already in use"
                                         userViewModel.errors = updatedErrors
-                                    } else if (response.code() == 400) {
+                                    }
+
+                                    if(response.code() == 409){
+                                        val updateErrors = userViewModel.errors.toMutableMap()
+                                        updateErrors["email"] = "Email already in use"
+                                    }
+
+                                    if (response.code() == 400) {
                                         val updatedErrors = userViewModel.errors.toMutableMap()
                                         updatedErrors["fields"] = "Required Fields are Missing"
                                         userViewModel.errors = updatedErrors

--- a/app/src/main/java/com/rrc/adev3007/pixel_perfect/the_y_app/CreateUserActivity.kt
+++ b/app/src/main/java/com/rrc/adev3007/pixel_perfect/the_y_app/CreateUserActivity.kt
@@ -80,6 +80,22 @@ fun CreateUserScreen(viewModel: SessionViewModel) {
         Spacer(modifier = Modifier.padding(bottom = 24.dp))
         if(userViewModel.errors.isNotEmpty()) ErrorMessages(userViewModel.errors)
         OutlinedTextField(
+            value = userViewModel.username,
+            label = { Text(text = "Username") },
+            onValueChange = {
+                userViewModel.username = it
+                val updatedErrors = userViewModel.errors.toMutableMap()
+                updatedErrors.remove("username")
+                userViewModel.errors = updatedErrors
+            },
+            placeholder = { Text(text = "Enter Username") },
+            shape = RoundedCornerShape(12.dp),
+            singleLine = true,
+            modifier = Modifier
+                .fillMaxWidth()
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        OutlinedTextField(
             value = userViewModel.email,
             label = { Text(text = "Email") },
             onValueChange = {
@@ -183,6 +199,7 @@ fun CreateUserScreen(viewModel: SessionViewModel) {
                         if(userViewModel.validateForm()) {
                             coroutineScope.launch {
                                 val user = UserCreate(
+                                    userViewModel.username,
                                     userViewModel.email,
                                     userViewModel.firstName,
                                     userViewModel.lastName,
@@ -190,7 +207,7 @@ fun CreateUserScreen(viewModel: SessionViewModel) {
                                 )
                                 val response = Synchronizer.api.postUser(user)
                                 if (response.isSuccessful) {
-                                    val createdUser = UserAuth(userViewModel.email, userViewModel.password)
+                                    val createdUser = UserAuth(userViewModel.username, userViewModel.password)
                                     val navigate = Intent(activity, LoginActivity::class.java)
                                     navigate.putExtra("CreatedUser", createdUser)
                                     activity.finish()
@@ -199,7 +216,7 @@ fun CreateUserScreen(viewModel: SessionViewModel) {
                                     Log.e("loginError", response.code().toString())
                                     if (response.code() == 416) {
                                         val updatedErrors = userViewModel.errors.toMutableMap()
-                                        updatedErrors["email"] = "Email is already in use!"
+                                        updatedErrors["username"] = "User already exists"
                                         userViewModel.errors = updatedErrors
                                     } else if (response.code() == 400) {
                                         val updatedErrors = userViewModel.errors.toMutableMap()

--- a/app/src/main/java/com/rrc/adev3007/pixel_perfect/the_y_app/CreateUserViewModel.kt
+++ b/app/src/main/java/com/rrc/adev3007/pixel_perfect/the_y_app/CreateUserViewModel.kt
@@ -10,6 +10,7 @@ class CreateUserViewModel : ViewModel() {
     var password by mutableStateOf("")
     var firstName by mutableStateOf("")
     var lastName by mutableStateOf("")
+    var username by mutableStateOf("")
     var errors by mutableStateOf<Map<String, String>>(emptyMap())
 
     fun validateEmail(): Map<String, String>{
@@ -43,6 +44,10 @@ class CreateUserViewModel : ViewModel() {
 
         if (lastName.isBlank()) {
             updatedErrors["lastName"] = "Last name is required"
+        }
+
+        if(username.isBlank()){
+            updatedErrors["username"] = "Username is required"
         }
 
         errors = updatedErrors

--- a/app/src/main/java/com/rrc/adev3007/pixel_perfect/the_y_app/LoginActivity.kt
+++ b/app/src/main/java/com/rrc/adev3007/pixel_perfect/the_y_app/LoginActivity.kt
@@ -80,8 +80,6 @@ fun LoginScreen(viewModel: SessionViewModel) {
                                 viewModel.updateLastName(userAccount?.lastName.toString())
                                 viewModel.updateScale((ScalingLevel.valueOf(userAccount?.uiScale.toString())))
                                 viewModel.updateProfilePicture(userAccount?.profilePicture?.toString())
-                                // placeholder to test username update
-                                viewModel.updateUsername("${viewModel.firstName.value} ${viewModel.lastName.value}")
                                 activity.finish()
                                 activity.startActivity(Intent(activity, HomeActivity::class.java))
                             } else {
@@ -205,8 +203,6 @@ fun LoginScreen(viewModel: SessionViewModel) {
                                     viewModel.updateLastName(userAccount?.lastName.toString())
                                     viewModel.updateScale((ScalingLevel.valueOf(userAccount?.uiScale.toString())))
                                     viewModel.updateProfilePicture(userAccount?.profilePicture?.toString())
-                                    //placeholder to test username update
-                                    viewModel.updateUsername("${viewModel.firstName.value} ${viewModel.lastName.value}")
                                     activity.finish()
                                     activity.startActivity(
                                         Intent(

--- a/app/src/main/java/com/rrc/adev3007/pixel_perfect/the_y_app/LoginActivity.kt
+++ b/app/src/main/java/com/rrc/adev3007/pixel_perfect/the_y_app/LoginActivity.kt
@@ -52,7 +52,7 @@ class LoginActivity : ComponentActivity() {
 
 @Composable
 fun LoginScreen(viewModel: SessionViewModel) {
-    var email by remember { mutableStateOf("") }
+    var username by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
     var passwordVisability by remember {
         mutableStateOf(true)
@@ -74,7 +74,8 @@ fun LoginScreen(viewModel: SessionViewModel) {
                             if (response.isSuccessful) {
                                 val userAccount = response.body()
                                 viewModel.setAPIKey(userAccount?.apiKey.toString())
-                                viewModel.updateEmail(userAuth.email)
+                                viewModel.updateUsername(userAuth.username)
+                                viewModel.updateEmail(userAccount?.email.toString())
                                 viewModel.updateFirstName(userAccount?.firstName.toString())
                                 viewModel.updateLastName(userAccount?.lastName.toString())
                                 viewModel.updateScale((ScalingLevel.valueOf(userAccount?.uiScale.toString())))
@@ -115,13 +116,13 @@ fun LoginScreen(viewModel: SessionViewModel) {
             Spacer(modifier = Modifier.padding(bottom = 24.dp))
             if (!errorString.isEmpty()) Text(text = errorString, color = Color.Red)
             OutlinedTextField(
-                value = email,
-                label = { Text(text = "Email") },
+                value = username,
+                label = { Text(text = "Username") },
                 onValueChange = {
-                    email = it
+                    username = it
                     errorString = ""
                 },
-                placeholder = { Text(text = "Enter Email") },
+                placeholder = { Text(text = "Enter Username") },
                 shape = RoundedCornerShape(12.dp),
                 singleLine = true,
                 modifier = Modifier
@@ -193,12 +194,13 @@ fun LoginScreen(viewModel: SessionViewModel) {
                         try {
                             isLoading = true
                             coroutineScope.launch {
-                                val loginAuth = UserAuth(email, password)
+                                val loginAuth = UserAuth(username, password)
                                 val response = Synchronizer.api.postLogin(loginAuth)
                                 if (response.isSuccessful) {
                                     val userAccount = response.body()
                                     viewModel.setAPIKey(userAccount?.apiKey.toString())
-                                    viewModel.updateEmail(email)
+                                    viewModel.updateUsername(username)
+                                    viewModel.updateEmail(userAccount?.email.toString())
                                     viewModel.updateFirstName(userAccount?.firstName.toString())
                                     viewModel.updateLastName(userAccount?.lastName.toString())
                                     viewModel.updateScale((ScalingLevel.valueOf(userAccount?.uiScale.toString())))
@@ -214,7 +216,7 @@ fun LoginScreen(viewModel: SessionViewModel) {
                                     )
                                 } else {
                                     Log.e("loginError", response.code().toString())
-                                    errorString = "Email or password is incorrect!"
+                                    errorString = "Username or password is incorrect!"
                                 }
                                 isLoading = false
                             }

--- a/app/src/main/java/com/rrc/adev3007/pixel_perfect/the_y_app/data/Synchronizer.kt
+++ b/app/src/main/java/com/rrc/adev3007/pixel_perfect/the_y_app/data/Synchronizer.kt
@@ -15,6 +15,7 @@ import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.POST
+import retrofit2.http.PUT
 import retrofit2.http.Query
 
 interface ISynchronizer {
@@ -26,10 +27,10 @@ interface ISynchronizer {
     @POST("post")
     suspend fun createPost(@Body data: CreatePostRequest) : Response<Any>
 
-    @POST("login")
+    @PUT("login")
     suspend fun postLogin(@Body loginAuth: UserAuth ) : Response<UserAccount>
 
-    @POST("user")
+    @PUT("user")
     suspend fun postUser(@Body createUser: UserCreate) : Response<Any>
 
     @PATCH("user")

--- a/app/src/main/java/com/rrc/adev3007/pixel_perfect/the_y_app/data/models/UserAccount.kt
+++ b/app/src/main/java/com/rrc/adev3007/pixel_perfect/the_y_app/data/models/UserAccount.kt
@@ -17,11 +17,12 @@ data class UserAccount(
     @SerializedName("profile_picture")
     val profilePicture: String?,
     @SerializedName("ui_scale")
-    val uiScale: String
+    val uiScale: String,
+    val email: String
 )
 
 data class UserAuth(
-    val email:String,
+    val username:String,
     val password: String
 ) : Serializable
 
@@ -31,7 +32,8 @@ data class UserCreate(
     val firstName: String,
     @SerializedName("last_name")
     val lastName: String,
-    val password: String
+    val password: String,
+    val username: String
 )
 
 data class UserProfilePicture(


### PR DESCRIPTION
Changed the HTTP request methods from "@POST" to "@PUT" for retrofit to match API endpoints.

Changes made to UserAccount file
- Changed email to username for the UserAuth data model.
- Added username to CreateUser data model.

Updated LoginActivity to use username instead of email for authenticating via API.

Added username textfield to CreateUserActivity.

Overall the refactor is to use username instead of email for logging in and saving username and email to sessions.